### PR TITLE
Added additional cask installs

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -127,6 +127,7 @@ brew install caskroom/cask/brew-cask
 brew cask install --appdir="/Applications" alfred
 brew cask install --appdir="~/Applications" iterm2
 brew cask install --appdir="~/Applications" java
+brew cask install --appdir="~/Applications" xquartz
 
 # Development tool casks
 brew cask install --appdir="/Applications" sublime-text
@@ -142,6 +143,8 @@ brew cask install --appdir="/Applications" skype
 brew cask install --appdir="/Applications" slack
 brew cask install --appdir="/Applications" dropbox
 brew cask install --appdir="/Applications" evernote
+#brew cask install --appdir="/Applications" gimp
+#brew cask install --appdir="/Applications" inkscape
 
 #Remove comment to install LaTeX distribution MacTeX
 #brew cask install --appdir="/Applications" mactex


### PR DESCRIPTION
Included cask for xquartz, the X11 window manager as quite commonly used to run graphical Linux applications. Also added Inkscape (a nice vector graphics application) and Gimp (Photoshop alternative) but have commented these out as not everyone will want them.