### PR TITLE
pip install virtualenv failed if PIP_REQUIRE_VIRTUALENV was true

### DIFF
--- a/pydata.sh
+++ b/pydata.sh
@@ -20,6 +20,8 @@ echo "------------------------------"
 echo "Setting up virtual environments."
 
 # Install virtual environments globally
+# It fails to install virtualenv if PIP_REQUIRE_VIRTUALENV was true
+export PIP_REQUIRE_VIRTUALENV=false
 pip install virtualenv
 pip install virtualenvwrapper
 

--- a/pydata.sh
+++ b/pydata.sh
@@ -101,6 +101,7 @@ echo "------------------------------"
 echo "Installing IPython Notebook Default Profile"
 
 # Add the IPython profile
+mkdir -p ~/.ipython
 cp -r init/profile_default/ ~/.ipython/profile_default
 
 echo "------------------------------"


### PR DESCRIPTION
setting this in the `.extra` file, as it is suggested in README.MD:
`export PIP_REQUIRE_VIRTUALENV=true`

made `pydata.sh` fail when calling `pip install virtualenv`
`Could not find an activated virtualenv (required).`

fix: export `PIP_REQUIRE_VIRTUALENV` to false inside pydata.sh

