### PR TITLE
Remove redundant cask install from android.sh

### DIFF
--- a/android.sh
+++ b/android.sh
@@ -19,11 +19,11 @@ fi
 brew update
 
 # Install Cask
-brew install caskroom/cask/brew-cask
-brew tap caskroom/versions
+# brew install caskroom/cask/brew-cask
+# brew tap caskroom/versions
 
 brew cask install --appdir="~/Applications" java
-brew cask install --appdir="~/Applications" Caskroom/versions/intellij-idea-ce
+brew cask install --appdir="~/Applications" intellij-idea-ce
 brew cask install --appdir="~/Applications" android-studio
 
 brew install android-sdk

--- a/android.sh
+++ b/android.sh
@@ -18,10 +18,6 @@ fi
 # Make sure we’re using the latest Homebrew.
 brew update
 
-# Install Cask
-# brew install caskroom/cask/brew-cask
-# brew tap caskroom/versions
-
 brew cask install --appdir="~/Applications" java
 brew cask install --appdir="~/Applications" intellij-idea-ce
 brew cask install --appdir="~/Applications" android-studio


### PR DESCRIPTION
no longer required to install cask
Caskroom/versions/intellij-idea-ce no longer requires Caskroom/versions