### PR TITLE
Set blazingly fast keyboard repeat rate

### DIFF
--- a/osx.sh
+++ b/osx.sh
@@ -185,7 +185,8 @@ defaults write com.apple.universalaccess closeViewZoomFollowsFocus -bool true
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
 
 # Set a blazingly fast keyboard repeat rate
-defaults write NSGlobalDomain KeyRepeat -int 0
+defaults write NSGlobalDomain KeyRepeat -int 1
+defaults write NSGlobalDomain InitialKeyRepeat -int 15
 
 # Set language and text formats
 #defaults write NSGlobalDomain AppleLanguages -array "en"


### PR DESCRIPTION
High Sierra broke the keyboard input rate fix
Use this to set "set a blazingly fast keyboard repeat rate"
defaults write NSGlobalDomain KeyRepeat -int 1
defaults write NSGlobalDomain InitialKeyRepeat -int 15

https://github.com/mathiasbynens/dotfiles/issues/687#issuecomment-248704551