### PR TITLE
Add support for Google Cloud Platform SDK

### DIFF
--- a/.dots
+++ b/.dots
@@ -95,6 +95,15 @@ function runDots() {
             echo ""
             ./android.sh
         fi
+        if [ $ARG == "gcp" ] || [ $ARG == "all" ]; then
+            # Run the gcp.sh Script
+            echo "------------------------------"
+            echo "Setting up GCP development environment."
+            echo "------------------------------"
+            echo ""
+            ./gcp.sh
+        fi
+
     done
 
     echo "------------------------------"

--- a/gcp.sh
+++ b/gcp.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+
+# This script might be run with .dots, which uses elevated privileges
+sudo -K
+
+# Make sure we’re using the latest Homebrew.
+brew update
+
+echo "------------------------------"
+echo "Getting GCP SDK."
+echo "------------------------------"
+
+# https://github.com/Homebrew/homebrew-core/issues/583
+brew tap caskroom/cask
+brew cask install google-cloud-sdk
+
+echo "------------------------------"
+echo "Setting up GCP SDK."
+echo "------------------------------"
+
+# this will disable usage-reporting, will update PATH for SDK, enable command-completion for SDK
+# --quiet will disable questions about PATH, command-completition and usage-reporting
+/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/install.sh --usage-reporting=false --quiet
+
+# Remove outdated versions from the cellar.
+brew cleanup


### PR DESCRIPTION
I propose to add support for Google Cloud Platform SDK (analogues to what is there for AWS).
[https://cloud.google.com/sdk/](url) 

GCP-SDK can be installed with brew, and need changes to local PATH. 
[https://github.com/Homebrew/homebrew-core/issues/583](url)

.dots file must be changed as well to incorporate the support for the new tool.  

