### PR TITLE
Fix #84: Update softwareupdate verbose flag

### DIFF
--- a/osxprep.sh
+++ b/osxprep.sh
@@ -10,7 +10,7 @@ while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 echo "------------------------------"
 echo "Updating OSX.  If this requires a restart, run the script again."
 # Install all available updates
-sudo softwareupdate -iva
+sudo softwareupdate -ia
 # Install only recommended available updates
 #sudo softwareupdate -irv
 

--- a/osxprep.sh
+++ b/osxprep.sh
@@ -10,9 +10,9 @@ while true; do sudo -n true; sleep 60; kill -0 "$$" || exit; done 2>/dev/null &
 echo "------------------------------"
 echo "Updating OSX.  If this requires a restart, run the script again."
 # Install all available updates
-sudo softwareupdate -ia
+sudo softwareupdate -ia --verbose
 # Install only recommended available updates
-#sudo softwareupdate -irv
+#sudo softwareupdate -ir --verbose
 
 echo "------------------------------"
 echo "Installing Xcode Command Line Tools."


### PR DESCRIPTION
For OSX Mojave:
$ sudo softwareupdate -iva
Password:
softwareupdate: invalid option -- v
usage: softwareupdate <cmd> [<args> ...]

** Manage Updates:
	-l | --list		List all appropriate update labels (options:  --no-scan, --product-types)
	-d | --download		Download Only
	-e | --cancel-download		Cancel a download
	-i | --install		Install
		<label> ...	specific updates
		-a | --all		All appropriate updates
		-R | --restart		Automatically restart (or shut down) if required to complete installation.
		-r | --recommended	Only recommended updates
	--background		Trigger a background scan and update operation
	--ignore <label> ...	Ignore specific updates
	--reset-ignored		Clear all ignored updates

** Other Tools:
	--dump-state		Log the internal state of the SU daemon to /var/log/install.log
	--evaluate-products	Evaluate a list of product keys specified by the --products option 
	--history		Show the install history.  By default, only displays updates installed by softwareupdate.  
	--all 			Include all processes in history (including App installs) 

** Options:
	--no-scan		Do not scan when listing or installing updates (use available updates previously scanned)
	--product-types <type>		Limit a scan to a particular product type only - ignoring all others
		Ex:  --product-types macOS  || --product-types macOS,Safari 
	--products		A comma-separated (no spaces) list of product keys to operate on. 
	--force			Force an operation to complete.  Use with --background to trigger a background scan regardless of "Automatically check" pref 

	--verbose		Enable verbose output
	--help			Print this help