### PR TITLE
Install Heroku CLI from heroku/brew/heroku

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -133,7 +133,7 @@ brew link libxml2 --force
 brew link libxslt --force
 
 # Install Heroku
-brew install heroku-toolbelt
+brew install heroku/brew/heroku
 heroku update
 
 # Core casks


### PR DESCRIPTION
According to https://devcenter.heroku.com/articles/heroku-cli the way to install Heroku CLI has changed.